### PR TITLE
update this to be able to run on a new box and old

### DIFF
--- a/dockerfiles/dashing/docker-restart.sh
+++ b/dockerfiles/dashing/docker-restart.sh
@@ -1,25 +1,35 @@
 #!/bin/bash
+set -o nounset
+set -o errexit
 
-cd /home/ec2-user/MortensonDashboard
+WORKDIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-git pull origin dev
+cd "${WORKDIR}"/../../
+git pull --all
+git checkout dev
 
-cd dockerfiles/dashing
+cd "${WORKDIR}"
 
-# docker build -t markkinsman/dashing .
+# if previous container with same name exists, delete it and build new
+if [[ -n $(docker ps -a | grep -i "field_dashboard" | awk '{print $1}') ]];
+then
+    echo -e "\nDeleting previous container named: field_dashboard"
+    docker ps -a | grep -i "field_dashboard" | awk '{print $1}' | xargs docker rm -f
+fi
 
-docker rm -f field_dashboard
-
-local_DIR="/home/ec2-user/MortensonDashboard/dockerfiles/dashing/"
+echo -e "\nBuilding new field_dashboard containter"
+docker build -t markkinsman/dashing .
 
 docker run -d -p 80:3030 \
     --name field_dashboard \
     -e GEMS="rest-client" \
-    -v="$local_DIR"widgets:/widgets \
-    -v="$local_DIR"config:/config \
-    -v="$local_DIR"public:/public \
-    -v="$local_DIR"jobs:/jobs \
-    -v="$local_DIR"dashboards:/dashboards \
+    -v="$WORKDIR"/widgets:/widgets \
+    -v="$WORKDIR"/config:/config \
+    -v="$WORKDIR"/public:/public \
+    -v="$WORKDIR"/jobs:/jobs \
+    -v="$WORKDIR"/dashboards:/dashboards \
     markkinsman/dashing
+
+docker ps
 
 echo -e "\nDone!\n"


### PR DESCRIPTION
This script still needs work but now should be easier to deploy to a new AWS instance.

I think it'll now be like this:
- create instance
- `ssh ec2-user@DNSNAME -i creds.pem "git clone $this_repo_url"`
- `ssh ec2-user@DNSNAME -i creds.pem "./home/ec2-user/MortensonDashboard/dockerfiles/dashing/docker-restart.sh"`

then that should have you with an instance running your dashboard on port 80
(this script switches to the dev branch manually, running master will need modification. might be a good idea to make that an $arg sometime down the road)
